### PR TITLE
docs: update nav and version tags

### DIFF
--- a/arch/actors/index.html
+++ b/arch/actors/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/apis/index.html
+++ b/arch/apis/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/app/index.html
+++ b/arch/app/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/cache/index.html
+++ b/arch/cache/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/cli/index.html
+++ b/arch/cli/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/commands/index.html
+++ b/arch/commands/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/context/index.html
+++ b/arch/context/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/data/index.html
+++ b/arch/data/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/diagram/index.html
+++ b/arch/diagram/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/email/index.html
+++ b/arch/email/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/entities/index.html
+++ b/arch/entities/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/files/index.html
+++ b/arch/files/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/generators/index.html
+++ b/arch/generators/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/jobs/index.html
+++ b/arch/jobs/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/notifications/index.html
+++ b/arch/notifications/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/overview/index.html
+++ b/arch/overview/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>
@@ -171,7 +167,7 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 3. The <span class="badge badge-success">Stable</span> tag indicates the module is a <strong>stable</strong> release. <br/>
 4. The <span class="badge badge-primary">Beta</span> tag indicates a module still in <strong>Beta</strong>, but soon to become a stable release.<br/>
 5. The <span class="badge badge-warning">Internal</span> tag indicates a module that is for internal use only <strong>( these may be replaced by other open-source libraries )</strong><br/>
-6. The <img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-results/images/download.svg" /> tag is a download link to <strong>Bintray</strong> for the <strong>gradle/maven</strong> instructions on installing the package <br/></p>
+6. The <img src="https://img.shields.io/badge/2.8.0-version-blue" /> tag is a download link to <strong>Github Packages</strong> for the <strong>gradle/maven</strong> instructions on installing the package <br/></p>
 
 <p></a>
 </div></p>
@@ -190,8 +186,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Android / Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-results">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-results/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -211,8 +208,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-app">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-app/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -232,8 +230,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-apis">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-apis/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -254,8 +253,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Android / Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-actors">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-actors/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -275,8 +275,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-cli">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-cli/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -296,8 +297,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Android / Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-cache">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-cache/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -330,8 +332,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Android / Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-context">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-context/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -351,8 +354,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Android / Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-entities">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-entities/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -372,8 +376,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-cloud">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-cloud/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -393,8 +398,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Android / Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-generator">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-generator/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -415,8 +421,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Android / Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-jobs">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-jobs/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -437,8 +444,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-notifications">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-notifications/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -459,8 +467,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-cloud">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-cloud/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -495,8 +504,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-notifications">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-notifications/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -517,8 +527,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Android / Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-tracking">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-tracking/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -538,8 +549,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Android / Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-common">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-common/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -559,8 +571,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Android / Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-common">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-common/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -580,8 +593,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Android / Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-common">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-common/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 
@@ -601,8 +615,9 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 <span class="badge badge-light">Android / Server</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-common">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-common/images/download.svg" />
+
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 

--- a/arch/queues/index.html
+++ b/arch/queues/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/results/index.html
+++ b/arch/results/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/server/index.html
+++ b/arch/server/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/sms/index.html
+++ b/arch/sms/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/arch/tracking/index.html
+++ b/arch/tracking/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/index.html
+++ b/index.html
@@ -75,9 +75,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -88,7 +85,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -100,10 +97,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -120,6 +114,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>
@@ -147,7 +143,7 @@
                 <div class="col-lg-5">
                     <div class="text">
                         <h1 class="wow fadeInUp"><span class="sk-color-2">Kiit</span><br/> Kotlin <strong>Framework</strong> <br/>For Apps, APIs, CLIs, Jobs, Mobile and more...</h1>
-                        <p class="wow fadeInUp">A modular set of Kotlin <a href="arch/overview" style="color:#ffffff; text-decoration:underline;">libraries </a> for building scalable and comprehensive applications. Many libraries are for the <strong>Server</strong> but also be used on <strong>Android</strong>. Multi-platform coming later.</p>
+                        <p class="wow fadeInUp">A modular set of Kotlin <a href="arch/overview" style="color:#ffffff; text-decoration:underline;">libraries </a> for building scalable and comprehensive applications. Many libraries are for the <strong>Server</strong> but can also be used on <strong>Android</strong>. Multi-platform coming later.</p>
                         <a href="start/start" class="sk-btn-white wow fadeInUp">Get Started</a>
                     </div>
                 </div>

--- a/info/contact/index.html
+++ b/info/contact/index.html
@@ -83,9 +83,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -96,7 +93,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -108,10 +105,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -128,6 +122,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/info/license/index.html
+++ b/info/license/index.html
@@ -83,9 +83,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -96,7 +93,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -108,10 +105,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -128,6 +122,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/info/scratch/index.html
+++ b/info/scratch/index.html
@@ -83,9 +83,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -96,7 +93,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -108,10 +105,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -128,6 +122,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/info/standards/index.html
+++ b/info/standards/index.html
@@ -83,9 +83,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -96,7 +93,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -108,10 +105,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -128,6 +122,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/src/hugo/slatekit-v3/content/arch/overview.md
+++ b/src/hugo/slatekit-v3/content/arch/overview.md
@@ -16,7 +16,7 @@ and scalable applications on the JVM. Several of the modules can be used for bot
 3. The <span class="badge badge-success">Stable</span> tag indicates the module is a **stable** release. <br/>
 4. The <span class="badge badge-primary">Beta</span> tag indicates a module still in **Beta**, but soon to become a stable release.<br/>
 5. The <span class="badge badge-warning">Internal</span> tag indicates a module that is for internal use only <strong>( these may be replaced by other open-source libraries )</strong><br/>
-6. The <img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-results/images/download.svg" /> tag is a download link to **Bintray** for the **gradle/maven** instructions on installing the package <br/>
+6. The <img src="https://img.shields.io/badge/2.8.0-version-blue" /> tag is a download link to **Github Packages** for the **gradle/maven** instructions on installing the package <br/>
 
 </a>
 </div>
@@ -31,7 +31,7 @@ and scalable applications on the JVM. Several of the modules can be used for bot
               <p>Models <strong>successes and failures</strong> with <strong>optional</strong> sub-categories of errors with codes. Works with exceptions, validations.
                  See {{% sk-link-arch name="results" %}} 
               </p>
-              {{% sk-version-download page="results" target="Android / Server" stable="abc" %}}
+              {{% sk-version-download page="results" target="Android / Server" stable="true" %}}
             </div>
           </div>
           <div class="col-md-4 wow fadeInUp">

--- a/src/hugo/slatekit-v3/themes/perfo/static/assets/app/app.js
+++ b/src/hugo/slatekit-v3/themes/perfo/static/assets/app/app.js
@@ -112,10 +112,10 @@ var codeHelixMeta = {
   
   product: 
   {
-	name : "Slate Kit",
-	slogan: "A scala toolkit, utility library and server backend",
-	about: 'Slate Kit is a product of <a href="http://www.codehelix.co">Code Helix Solutions Inc.</a>.',
-	needhelp: 'For more information on Slate Kit, including source code visit our github repository and feel free to email/contact us at <a href="mailto:kishore@codehelix.co">kishore@codehelix.co</a>',
+	name : "Kiit",
+	slogan: "A Kotlin Framework for Apps, APIs, CLIs, Jobs, Mobile and more",
+	about: 'Kiit is a product of <a href="http://www.codehelix.co">Code Helix Solutions Inc.</a>.',
+	needhelp: 'For more information on Kiit, including source code visit our github repository and feel free to email/contact us at <a href="mailto:kishore@codehelix.co">kishore@codehelix.co</a>',
 	questions: 'Questions ? Contact us via <a href="https://github.com/slatekit/slatekit">github</a> or at <a href="http://www.codehelix.co">Code Helix Solutions Inc.</a>'
   },
   

--- a/src/hugo/slatekit-v3/themes/wavo/layouts/index.html
+++ b/src/hugo/slatekit-v3/themes/wavo/layouts/index.html
@@ -57,7 +57,7 @@
                 <div class="col-lg-5">
                     <div class="text">
                         <h1 class="wow fadeInUp"><span class="sk-color-2">Kiit</span><br/> Kotlin <strong>Framework</strong> <br/>For Apps, APIs, CLIs, Jobs, Mobile and more...</h1>
-                        <p class="wow fadeInUp">A modular set of Kotlin <a href="arch/overview" style="color:#ffffff; text-decoration:underline;">libraries </a> for building scalable and comprehensive applications. Many libraries are for the <strong>Server</strong> but also be used on <strong>Android</strong>. Multi-platform coming later.</p>
+                        <p class="wow fadeInUp">A modular set of Kotlin <a href="arch/overview" style="color:#ffffff; text-decoration:underline;">libraries </a> for building scalable and comprehensive applications. Many libraries are for the <strong>Server</strong> but can also be used on <strong>Android</strong>. Multi-platform coming later.</p>
                         <a href="start/start" class="sk-btn-white wow fadeInUp">Get Started</a>
                     </div>
                 </div>

--- a/src/hugo/slatekit-v3/themes/wavo/layouts/partials/nav.html
+++ b/src/hugo/slatekit-v3/themes/wavo/layouts/partials/nav.html
@@ -7,9 +7,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -20,7 +17,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -32,10 +29,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     <!--
     <li class="nav-item dropdown">
@@ -85,6 +79,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             <!--
             <li><a class="dropdown-item" href="users/freelancers">Freelancers</a></li>
             <li><a class="dropdown-item" href="users/startups">Start-Ups</a></li>

--- a/src/hugo/slatekit-v3/themes/wavo/layouts/shortcodes/sk-modules.html
+++ b/src/hugo/slatekit-v3/themes/wavo/layouts/shortcodes/sk-modules.html
@@ -22,7 +22,7 @@
   <tr>
     <td class="text-center"><a href="arch/results"><img src="assets/media/img/white/target.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/results">Results</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-results/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -31,7 +31,7 @@
   <tr>
     <td class="text-center"><a href="/utils/overview"><img src="assets/media/img/white/multitool.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/utils/overview">Utilities</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-common/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -40,7 +40,7 @@
   <tr>
     <td class="text-center"><a href="/arch/context"><img src="assets/media/img/white/connected.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/context">Context</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-context/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -49,7 +49,7 @@
   <tr>
     <td class="text-center"><a href="/arch/actors"><img src="assets/media/img/white/gears.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/actors">Actors</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-actors/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -70,7 +70,7 @@
   <tr>
     <td class="text-center"><a href="/arch/app"><img src="assets/media/img/white/desktop.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/app">App</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-app/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -79,7 +79,7 @@
   <tr>
     <td class="text-center"><a href="/arch/cli"><img src="assets/media/img/white/terminal.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/cli">CLI</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-cli/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -88,7 +88,7 @@
   <tr>
     <td class="text-center"><a href="/arch/apis"><img src="assets/media/img/white/webapi.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/apis">Server</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-apis/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -97,7 +97,7 @@
   <tr>
     <td class="text-center"><a href="/arch/apis"><img src="assets/media/img/white/webapi.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/apis">API</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-server/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server / Console</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -106,7 +106,7 @@
   <tr>
     <td class="text-center"><a href="/arch/jobs"><img src="assets/media/img/white/gears.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/jobs">Jobs</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-jobs/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -128,7 +128,7 @@
   <tr>
     <td class="text-center"><a href="/arch/cache"><img src="assets/media/img/white/lightning.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/cache">Cache</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-cache/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -137,7 +137,7 @@
   <tr>
     <td class="text-center"><a href="/arch/queues"><img src="assets/media/img/white/queue.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/queues">Core</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-core/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -146,7 +146,7 @@
   <tr>
     <td class="text-center"><a href="/arch/sms"><img src="assets/media/img/white/mobile.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/sms">Notifications</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-notifications/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -155,7 +155,7 @@
   <tr>
     <td class="text-center"><a href="/arch/tracking"><img src="assets/media/img/white/diagnostic.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/tracking">Tracking</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-tracking/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -177,7 +177,7 @@
   <tr>
     <td class="text-center"><a href="/arch/data"><img src="assets/media/img/white/layers.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/data">DB</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-db/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -186,7 +186,7 @@
   <tr>
     <td class="text-center"><a href="/arch/data"><img src="assets/media/img/white/layers.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/data">Query</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-query/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -195,7 +195,7 @@
   <tr>
     <td class="text-center"><a href="/arch/data"><img src="assets/media/img/white/layers.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/data">Data</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-data/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -204,7 +204,7 @@
   <tr>
     <td class="text-center"><a href="/arch/data"><img src="assets/media/img/white/layers.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/data">Entities</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-entities/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -226,7 +226,7 @@
   <tr>
     <td class="text-center"><a href="/arch/generators"><img src="assets/media/img/white/terminal.png" width="40" alt="" /></a></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit" >Slate Kit</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-generator/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server / Console</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -235,7 +235,7 @@
   <tr>
     <td class="text-center"><a href="/arch/generators"><img src="assets/media/img/white/prototype.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/generators">Generator</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-generator/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server / Console</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -257,7 +257,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/module.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-providers-logback" >Logback</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-providers-logback/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -266,7 +266,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/module.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-providers-datadog" >DataDog</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-providers-datadog/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -275,7 +275,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/module.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-providers-aws" >AWS</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-providers-aws/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -297,7 +297,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/gears.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-connectors-cli" >API / CLI</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-connectors-cli/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server / Console</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -306,7 +306,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/gears.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-connectors-jobs" >API / Jobs</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-connectors-jobs/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -315,7 +315,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/gears.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-connectors-entities" >Entities/DB</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-connectors-entities/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -337,7 +337,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/shield.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit-http" >Http</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-http/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -346,7 +346,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/shield.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit-meta" >Meta</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-meta/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -355,7 +355,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/shield.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit-policy" >Policy</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-policy/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -364,7 +364,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/shield.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit-serialization" >Serialization</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-serialization/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>

--- a/src/hugo/slatekit-v3/themes/wavo/layouts/shortcodes/sk-version-download.html
+++ b/src/hugo/slatekit-v3/themes/wavo/layouts/shortcodes/sk-version-download.html
@@ -2,8 +2,9 @@
 <span class="badge badge-light">{{.Get "target" }}</span>
 <br/>
 
-<a href="https://bintray.com/codehelixinc/slatekit/slatekit-{{.Get "page" }}">
-<img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-{{.Get "page" }}/images/download.svg" />
+<!--<a href="https://bintray.com/codehelixinc/slatekit/slatekit-{{.Get "page" }}">-->
+<a href="https://github.com/orgs/slatekit/packages?repo_name=slatekit">
+<img src="https://img.shields.io/badge/2.8.0-version-blue" />
 </a>
 <br/>
 

--- a/start/generators/index.html
+++ b/start/generators/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/start/hello_world/index.html
+++ b/start/hello_world/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/start/kotlin101/index.html
+++ b/start/kotlin101/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/start/kotlin101src/index.html
+++ b/start/kotlin101src/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/start/overview/index.html
+++ b/start/overview/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>
@@ -339,7 +335,7 @@
   <tr>
     <td class="text-center"><a href="arch/results"><img src="assets/media/img/white/target.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/results">Results</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-results/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -348,7 +344,7 @@
   <tr>
     <td class="text-center"><a href="/utils/overview"><img src="assets/media/img/white/multitool.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/utils/overview">Utilities</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-common/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -357,7 +353,7 @@
   <tr>
     <td class="text-center"><a href="/arch/context"><img src="assets/media/img/white/connected.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/context">Context</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-context/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -366,7 +362,7 @@
   <tr>
     <td class="text-center"><a href="/arch/actors"><img src="assets/media/img/white/gears.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/actors">Actors</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-actors/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -387,7 +383,7 @@
   <tr>
     <td class="text-center"><a href="/arch/app"><img src="assets/media/img/white/desktop.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/app">App</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-app/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -396,7 +392,7 @@
   <tr>
     <td class="text-center"><a href="/arch/cli"><img src="assets/media/img/white/terminal.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/cli">CLI</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-cli/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -405,7 +401,7 @@
   <tr>
     <td class="text-center"><a href="/arch/apis"><img src="assets/media/img/white/webapi.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/apis">Server</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-apis/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -414,7 +410,7 @@
   <tr>
     <td class="text-center"><a href="/arch/apis"><img src="assets/media/img/white/webapi.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/apis">API</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-server/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server / Console</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -423,7 +419,7 @@
   <tr>
     <td class="text-center"><a href="/arch/jobs"><img src="assets/media/img/white/gears.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/jobs">Jobs</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-jobs/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -445,7 +441,7 @@
   <tr>
     <td class="text-center"><a href="/arch/cache"><img src="assets/media/img/white/lightning.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/cache">Cache</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-cache/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -454,7 +450,7 @@
   <tr>
     <td class="text-center"><a href="/arch/queues"><img src="assets/media/img/white/queue.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/queues">Core</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-core/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -463,7 +459,7 @@
   <tr>
     <td class="text-center"><a href="/arch/sms"><img src="assets/media/img/white/mobile.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/sms">Notifications</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-notifications/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -472,7 +468,7 @@
   <tr>
     <td class="text-center"><a href="/arch/tracking"><img src="assets/media/img/white/diagnostic.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/tracking">Tracking</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-tracking/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -494,7 +490,7 @@
   <tr>
     <td class="text-center"><a href="/arch/data"><img src="assets/media/img/white/layers.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/data">DB</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-db/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -503,7 +499,7 @@
   <tr>
     <td class="text-center"><a href="/arch/data"><img src="assets/media/img/white/layers.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/data">Query</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-query/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -512,7 +508,7 @@
   <tr>
     <td class="text-center"><a href="/arch/data"><img src="assets/media/img/white/layers.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/data">Data</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-data/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -521,7 +517,7 @@
   <tr>
     <td class="text-center"><a href="/arch/data"><img src="assets/media/img/white/layers.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/data">Entities</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-entities/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -543,7 +539,7 @@
   <tr>
     <td class="text-center"><a href="/arch/generators"><img src="assets/media/img/white/terminal.png" width="40" alt="" /></a></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit" >Slate Kit</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-generator/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server / Console</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -552,7 +548,7 @@
   <tr>
     <td class="text-center"><a href="/arch/generators"><img src="assets/media/img/white/prototype.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/generators">Generator</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-generator/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server / Console</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -574,7 +570,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/module.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-providers-logback" >Logback</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-providers-logback/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -583,7 +579,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/module.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-providers-datadog" >DataDog</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-providers-datadog/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -592,7 +588,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/module.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-providers-aws" >AWS</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-providers-aws/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -614,7 +610,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/gears.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-connectors-cli" >API / CLI</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-connectors-cli/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server / Console</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -623,7 +619,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/gears.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-connectors-jobs" >API / Jobs</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-connectors-jobs/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -632,7 +628,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/gears.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-connectors-entities" >Entities/DB</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-connectors-entities/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -654,7 +650,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/shield.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit-http" >Http</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-http/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -663,7 +659,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/shield.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit-meta" >Meta</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-meta/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -672,7 +668,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/shield.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit-policy" >Policy</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-policy/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -681,7 +677,7 @@
   <tr>
     <td class="text-center"><img src="assets/media/img/white/shield.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit-serialization" >Serialization</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-serialization/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>

--- a/start/setup/index.html
+++ b/start/setup/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/start/start/index.html
+++ b/start/start/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/start/updates/index.html
+++ b/start/updates/index.html
@@ -84,9 +84,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -97,7 +94,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -109,10 +106,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -129,6 +123,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>
@@ -221,7 +217,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="arch/results"><img src="assets/media/img/white/target.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/results">Results</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-results/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -230,7 +226,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/utils/overview"><img src="assets/media/img/white/multitool.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/utils/overview">Utilities</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-common/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -239,7 +235,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/context"><img src="assets/media/img/white/connected.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/context">Context</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-context/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -248,7 +244,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/actors"><img src="assets/media/img/white/gears.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/actors">Actors</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-actors/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -269,7 +265,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/app"><img src="assets/media/img/white/desktop.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/app">App</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-app/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -278,7 +274,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/cli"><img src="assets/media/img/white/terminal.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/cli">CLI</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-cli/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -287,7 +283,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/apis"><img src="assets/media/img/white/webapi.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/apis">Server</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-apis/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -296,7 +292,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/apis"><img src="assets/media/img/white/webapi.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/apis">API</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-server/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server / Console</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -305,7 +301,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/jobs"><img src="assets/media/img/white/gears.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/jobs">Jobs</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-jobs/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -327,7 +323,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/cache"><img src="assets/media/img/white/lightning.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="/arch/cache">Cache</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-cache/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -336,7 +332,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/queues"><img src="assets/media/img/white/queue.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/queues">Core</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-core/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -345,7 +341,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/sms"><img src="assets/media/img/white/mobile.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/sms">Notifications</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-notifications/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -354,7 +350,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/tracking"><img src="assets/media/img/white/diagnostic.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/tracking">Tracking</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-tracking/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -376,7 +372,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/data"><img src="assets/media/img/white/layers.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/data">DB</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-db/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -385,7 +381,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/data"><img src="assets/media/img/white/layers.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/data">Query</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-query/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -394,7 +390,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/data"><img src="assets/media/img/white/layers.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/data">Data</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-data/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -403,7 +399,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/data"><img src="assets/media/img/white/layers.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/data">Entities</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-entities/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -425,7 +421,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/generators"><img src="assets/media/img/white/terminal.png" width="40" alt="" /></a></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit" >Slate Kit</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-generator/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server / Console</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -434,7 +430,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><a href="/arch/generators"><img src="assets/media/img/white/prototype.png" width="40" alt="" /></a></td>
     <td><strong><a class="url-ch" href="arch/generators">Generator</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-generator/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server / Console</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -456,7 +452,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><img src="assets/media/img/white/module.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-providers-logback" >Logback</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-providers-logback/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -465,7 +461,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><img src="assets/media/img/white/module.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-providers-datadog" >DataDog</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-providers-datadog/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -474,7 +470,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><img src="assets/media/img/white/module.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-providers-aws" >AWS</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-providers-aws/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -496,7 +492,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><img src="assets/media/img/white/gears.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-connectors-cli" >API / CLI</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-connectors-cli/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server / Console</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -505,7 +501,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><img src="assets/media/img/white/gears.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-connectors-jobs" >API / Jobs</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-connectors-jobs/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -514,7 +510,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><img src="assets/media/img/white/gears.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/ext/kotlin/slatekit-connectors-entities" >Entities/DB</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-connectors-entities/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -536,7 +532,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><img src="assets/media/img/white/shield.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit-http" >Http</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-http/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -545,7 +541,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><img src="assets/media/img/white/shield.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit-meta" >Meta</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-meta/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -554,7 +550,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><img src="assets/media/img/white/shield.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit-policy" >Policy</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-policy/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>
@@ -563,7 +559,7 @@ There is also a <strong>Homebrew installer</strong> for Mac OS for using the <st
   <tr>
     <td class="text-center"><img src="assets/media/img/white/shield.png" width="40" alt="" /></td>
     <td><strong><a href="https://github.com/slatekit/slatekit/tree/master/src/lib/kotlin/slatekit-serialization" >Serialization</a></strong></td>
-    <td><img src="https://api.bintray.com/packages/codehelixinc/slatekit/slatekit-serialization/images/download.svg" /></td>
+    <td><img src="https://img.shields.io/badge/2.8.0-version-blue" /></td>
     <td><span class="badge badge-light">Android / Server</span></td>
     <td><span class="badge badge-success">Stable</span></td>
     <td><img src="https://img.shields.io/badge/license-Apache-orange.svg?style=flat" /></td>

--- a/utils/args/index.html
+++ b/utils/args/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/auth/index.html
+++ b/utils/auth/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/config/index.html
+++ b/utils/config/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/console/index.html
+++ b/utils/console/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/data/index.html
+++ b/utils/data/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/datetime/index.html
+++ b/utils/datetime/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/dblookup/index.html
+++ b/utils/dblookup/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/encrypt/index.html
+++ b/utils/encrypt/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/env/index.html
+++ b/utils/env/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/folders/index.html
+++ b/utils/folders/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/info/index.html
+++ b/utils/info/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/lex/index.html
+++ b/utils/lex/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/logger/index.html
+++ b/utils/logger/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/model/index.html
+++ b/utils/model/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/overview/index.html
+++ b/utils/overview/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/random/index.html
+++ b/utils/random/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/reflect/index.html
+++ b/utils/reflect/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/request/index.html
+++ b/utils/request/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/results/index.html
+++ b/utils/results/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/serialization/index.html
+++ b/utils/serialization/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/smartvalues/index.html
+++ b/utils/smartvalues/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/templates/index.html
+++ b/utils/templates/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/todo/index.html
+++ b/utils/todo/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/utils/index.html
+++ b/utils/utils/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>

--- a/utils/validations/index.html
+++ b/utils/validations/index.html
@@ -79,9 +79,6 @@
         <a class="nav-link" href="/start/overview">Overview</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="/start/updates">Updates</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link" href="/start/start">Start</a>
     </li>
     <li class="nav-item dropdown">
@@ -92,7 +89,7 @@
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
-            Modules
+            Guides
         </a>
         <ul class="dropdown-menu" aria-labelledby="menu-1">
             <li><a class="dropdown-item" href="arch/overview">Overview</a></li>
@@ -104,10 +101,7 @@
         </ul>
     </li>
     <li class="nav-item">
-        <a class="nav-link" href="utils/overview">Utilities</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="/info/license">License</a>
+        <a class="nav-link" href="/start/updates">Updates</a>
     </li>
     
     <li class="nav-item dropdown">
@@ -124,6 +118,8 @@
             <li><a class="dropdown-item" href="https://github.com/slatekit/slatekit/releases">Releases</a></li>
             <li><a class="dropdown-item" href="info/about">About</a></li>
             <li><a class="dropdown-item" href="info/contact">Contact</a></li>
+            <li><a class="dropdown-item" href="/info/license">License</a></li>
+            
             
             <li><a class="dropdown-item" href="info/faq">FAQ</a></li>
             <li><a class="dropdown-item" href="info/standards">Standards</a></li>


### PR DESCRIPTION
# Overview
Update the top nav bar for simplification and include version badges.

# Changes
1. Nav: Moved `license` to `more` 
2. Nav: Removed `utilities` link
3. Nav: Renamed `Modules` to `Guides`
4. Nav: Moved `Updates` to after `Guides`
5. Badges: Referencing shields.io for `2.8.0` version badge where applicable.
